### PR TITLE
Writing unit tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --all --verbose
 
   clippy_check:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,8 @@ log="0.4"
 env_logger = "0.8.4"
 bytes = "1"
 rand = "0.8.0"
+
+[workspace]
+members = [
+	"redis-protocol-parser",
+]

--- a/src/cmd/hash.rs
+++ b/src/cmd/hash.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 pub fn hdel(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    conn.db().get_map(
+    conn.db().get_map_or(
         &args[1],
         |v| match v {
             Value::Hash(h) => {
@@ -33,44 +33,53 @@ pub fn hdel(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
 }
 
 pub fn hexists(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    match conn.db().get(&args[1]) {
-        Value::Hash(h) => Ok(if h.read().get(&args[2]).is_some() {
-            1_i64.into()
-        } else {
-            0_i64.into()
-        }),
-        Value::Null => Ok(0_i64.into()),
-        _ => Err(Error::WrongType),
-    }
+    conn.db().get_map_or(
+        &args[1],
+        |v| match v {
+            Value::Hash(h) => Ok(if h.read().get(&args[2]).is_some() {
+                1_i64.into()
+            } else {
+                0_i64.into()
+            }),
+            _ => Err(Error::WrongType),
+        },
+        || Ok(0_i64.into()),
+    )
 }
 
 pub fn hget(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    match conn.db().get(&args[1]) {
-        Value::Hash(h) => Ok(if let Some(v) = h.read().get(&args[2]) {
-            Value::Blob(v.clone())
-        } else {
-            Value::Null
-        }),
-        Value::Null => Ok(Value::Null),
-        _ => Err(Error::WrongType),
-    }
+    conn.db().get_map_or(
+        &args[1],
+        |v| match v {
+            Value::Hash(h) => Ok(if let Some(v) = h.read().get(&args[2]) {
+                Value::Blob(v.clone())
+            } else {
+                Value::Null
+            }),
+            _ => Err(Error::WrongType),
+        },
+        || Ok(Value::Null),
+    )
 }
 
 pub fn hgetall(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    match conn.db().get(&args[1]) {
-        Value::Hash(h) => {
-            let mut ret = vec![];
+    conn.db().get_map_or(
+        &args[1],
+        |v| match v {
+            Value::Hash(h) => {
+                let mut ret = vec![];
 
-            for (key, value) in h.read().iter() {
-                ret.push(Value::Blob(key.clone()));
-                ret.push(Value::Blob(value.clone()));
+                for (key, value) in h.read().iter() {
+                    ret.push(Value::Blob(key.clone()));
+                    ret.push(Value::Blob(value.clone()));
+                }
+
+                Ok(ret.into())
             }
-
-            Ok(ret.into())
-        }
-        Value::Null => Ok(Value::Array(vec![])),
-        _ => Err(Error::WrongType),
-    }
+            _ => Err(Error::WrongType),
+        },
+        || Ok(Value::Array(vec![])),
+    )
 }
 
 pub fn hincrby<
@@ -79,7 +88,7 @@ pub fn hincrby<
     conn: &Connection,
     args: &[Bytes],
 ) -> Result<Value, Error> {
-    conn.db().get_map(
+    conn.db().get_map_or(
         &args[1],
         |v| match v {
             Value::Hash(h) => {
@@ -107,49 +116,58 @@ pub fn hincrby<
 }
 
 pub fn hkeys(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    match conn.db().get(&args[1]) {
-        Value::Hash(h) => {
-            let mut ret = vec![];
+    conn.db().get_map_or(
+        &args[1],
+        |v| match v {
+            Value::Hash(h) => {
+                let mut ret = vec![];
 
-            for key in h.read().keys() {
-                ret.push(Value::Blob(key.clone()));
+                for key in h.read().keys() {
+                    ret.push(Value::Blob(key.clone()));
+                }
+
+                Ok(ret.into())
             }
-
-            Ok(ret.into())
-        }
-        Value::Null => Ok(Value::Array(vec![])),
-        _ => Err(Error::WrongType),
-    }
+            _ => Err(Error::WrongType),
+        },
+        || Ok(Value::Array(vec![])),
+    )
 }
 
 pub fn hlen(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    match conn.db().get(&args[1]) {
-        Value::Hash(h) => Ok((h.read().len() as i64).into()),
-        Value::Null => Ok(0_i64.into()),
-        _ => Err(Error::WrongType),
-    }
+    conn.db().get_map_or(
+        &args[1],
+        |v| match v {
+            Value::Hash(h) => Ok((h.read().len() as i64).into()),
+            _ => Err(Error::WrongType),
+        },
+        || Ok(0_i64.into()),
+    )
 }
 
 pub fn hmget(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    match conn.db().get(&args[1]) {
-        Value::Hash(h) => {
-            let h = h.read();
+    conn.db().get_map_or(
+        &args[1],
+        |v| match v {
+            Value::Hash(h) => {
+                let h = h.read();
 
-            Ok((&args[2..])
-                .iter()
-                .map(|key| {
-                    if let Some(value) = h.get(key) {
-                        Value::Blob(value.clone())
-                    } else {
-                        Value::Null
-                    }
-                })
-                .collect::<Vec<Value>>()
-                .into())
-        }
-        Value::Null => Ok(Value::Array(vec![])),
-        _ => Err(Error::WrongType),
-    }
+                Ok((&args[2..])
+                    .iter()
+                    .map(|key| {
+                        if let Some(value) = h.get(key) {
+                            Value::Blob(value.clone())
+                        } else {
+                            Value::Null
+                        }
+                    })
+                    .collect::<Vec<Value>>()
+                    .into())
+            }
+            _ => Err(Error::WrongType),
+        },
+        || Ok(Value::Array(vec![])),
+    )
 }
 
 pub fn hrandfield(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
@@ -174,53 +192,56 @@ pub fn hrandfield(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
         (1, true, 1)
     };
 
-    match conn.db().get(&args[1]) {
-        Value::Hash(h) => {
-            let mut ret = vec![];
-            let mut i = 0;
-            let mut rand_sorted = BTreeMap::new();
-            let mut rng = rand::thread_rng();
-            let h = h.read();
+    conn.db().get_map_or(
+        &args[1],
+        |v| match v {
+            Value::Hash(h) => {
+                let mut ret = vec![];
+                let mut i = 0;
+                let mut rand_sorted = BTreeMap::new();
+                let mut rng = rand::thread_rng();
+                let h = h.read();
 
-            for _ in 0..repeat {
-                for (key, value) in h.iter() {
-                    let rand = rng.gen::<u64>();
-                    rand_sorted.insert((rand, i), (key, value));
+                for _ in 0..repeat {
+                    for (key, value) in h.iter() {
+                        let rand = rng.gen::<u64>();
+                        rand_sorted.insert((rand, i), (key, value));
+                        i += 1;
+                    }
+                }
+
+                i = 0;
+                for val in rand_sorted.values() {
+                    if single {
+                        return Ok(Value::Blob(val.0.clone()));
+                    }
+
+                    if i == count {
+                        break;
+                    }
+
+                    ret.push(Value::Blob(val.0.clone()));
+
+                    if with_values {
+                        ret.push(Value::Blob(val.1.clone()));
+                    }
+
                     i += 1;
                 }
+
+                Ok(ret.into())
             }
-
-            i = 0;
-            for val in rand_sorted.values() {
-                if single {
-                    return Ok(Value::Blob(val.0.clone()));
-                }
-
-                if i == count {
-                    break;
-                }
-
-                ret.push(Value::Blob(val.0.clone()));
-
-                if with_values {
-                    ret.push(Value::Blob(val.1.clone()));
-                }
-
-                i += 1;
-            }
-
-            Ok(ret.into())
-        }
-        Value::Null => Ok(Value::Array(vec![])),
-        _ => Err(Error::WrongType),
-    }
+            _ => Err(Error::WrongType),
+        },
+        || Ok(Value::Array(vec![])),
+    )
 }
 
 pub fn hset(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
     if args.len() % 2 == 1 {
         return Err(Error::InvalidArgsCount("hset".to_owned()));
     }
-    conn.db().get_map(
+    conn.db().get_map_or(
         &args[1],
         |v| match v {
             Value::Hash(h) => {
@@ -249,7 +270,7 @@ pub fn hset(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
 }
 
 pub fn hsetnx(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    conn.db().get_map(
+    conn.db().get_map_or(
         &args[1],
         |v| match v {
             Value::Hash(h) => {
@@ -278,29 +299,176 @@ pub fn hsetnx(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
 }
 
 pub fn hstrlen(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    match conn.db().get(&args[1]) {
-        Value::Hash(h) => Ok(if let Some(v) = h.read().get(&args[2]) {
-            (v.len() as i64).into()
-        } else {
-            0_i64.into()
-        }),
-        Value::Null => Ok(0_i64.into()),
-        _ => Err(Error::WrongType),
-    }
+    conn.db().get_map_or(
+        &args[1],
+        |v| match v {
+            Value::Hash(h) => Ok(if let Some(v) = h.read().get(&args[2]) {
+                (v.len() as i64).into()
+            } else {
+                0_i64.into()
+            }),
+            _ => Err(Error::WrongType),
+        },
+        || Ok(0_i64.into()),
+    )
 }
 
 pub fn hvals(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    match conn.db().get(&args[1]) {
-        Value::Hash(h) => {
-            let mut ret = vec![];
+    conn.db().get_map_or(
+        &args[1],
+        |v| match v {
+            Value::Hash(h) => {
+                let mut ret = vec![];
 
-            for value in h.read().values() {
-                ret.push(Value::Blob(value.clone()));
+                for value in h.read().values() {
+                    ret.push(Value::Blob(value.clone()));
+                }
+
+                Ok(ret.into())
             }
+            _ => Err(Error::WrongType),
+        },
+        || Ok(Value::Array(vec![])),
+    )
+}
 
-            Ok(ret.into())
-        }
-        Value::Null => Ok(Value::Array(vec![])),
-        _ => Err(Error::WrongType),
+#[cfg(test)]
+mod test {
+    use crate::{
+        cmd::test::{create_connection, run_command},
+        value::Value,
+    };
+
+    #[test]
+    fn hget() {
+        let c = create_connection();
+        let r = run_command(&c, &["hset", "foo", "f1", "1", "f2", "2", "f3", "3"]);
+
+        assert_eq!(Ok(Value::Integer(3)), r);
+
+        let r = run_command(&c, &["hget", "foo", "f1"]);
+        assert_eq!(Ok(Value::Blob("1".into())), r);
+    }
+
+    #[test]
+    fn hgetall() {
+        let c = create_connection();
+        let r = run_command(&c, &["hset", "foo", "f1", "1", "f2", "2", "f3", "3"]);
+
+        assert_eq!(Ok(Value::Integer(3)), r);
+
+        let r = run_command(&c, &["hgetall", "foo"]);
+        match r {
+            Ok(Value::Array(x)) => {
+                assert_eq!(6, x.len());
+                assert!(
+                    x[0] == Value::Blob("f1".into())
+                        || x[0] == Value::Blob("f2".into())
+                        || x[0] == Value::Blob("f3".into())
+                )
+            }
+            _ => assert!(false),
+        };
+    }
+
+    #[test]
+    fn hrandfield() {
+        let c = create_connection();
+        let r = run_command(&c, &["hset", "foo", "f1", "1", "f2", "2", "f3", "3"]);
+
+        assert_eq!(Ok(Value::Integer(3)), r);
+
+        let r = run_command(&c, &["hrandfield", "foo"]);
+        match r {
+            Ok(Value::Blob(x)) => {
+                let x = unsafe { std::str::from_utf8_unchecked(&x) };
+                assert!(x == "f1".to_owned() || x == "f2".to_owned() || x == "f3".to_owned());
+            }
+            _ => assert!(false),
+        };
+    }
+
+    #[test]
+    fn hmget() {
+        let c = create_connection();
+        let r = run_command(&c, &["hset", "foo", "f1", "1", "f2", "2", "f3", "3"]);
+
+        assert_eq!(Ok(Value::Integer(3)), r);
+
+        let r = run_command(&c, &["hmget", "foo", "f1", "f2"]);
+        assert_eq!(
+            Ok(Value::Array(vec![
+                Value::Blob("1".into()),
+                Value::Blob("2".into()),
+            ])),
+            r
+        );
+    }
+
+    #[test]
+    fn hexists() {
+        let c = create_connection();
+        let r = run_command(&c, &["hset", "foo", "f1", "1", "f2", "2", "f3", "3"]);
+
+        assert_eq!(Ok(Value::Integer(3)), r);
+
+        assert_eq!(
+            Ok(Value::Integer(1)),
+            run_command(&c, &["hexists", "foo", "f1"])
+        );
+        assert_eq!(
+            Ok(Value::Integer(1)),
+            run_command(&c, &["hexists", "foo", "f3"])
+        );
+        assert_eq!(
+            Ok(Value::Integer(0)),
+            run_command(&c, &["hexists", "foo", "f4"])
+        );
+    }
+    #[test]
+    fn hstrlen() {
+        let c = create_connection();
+        let r = run_command(&c, &["hset", "foo", "f1", "1", "f2", "2", "f3", "3"]);
+
+        assert_eq!(Ok(Value::Integer(3)), r);
+
+        let r = run_command(&c, &["hstrlen", "foo", "f1"]);
+        assert_eq!(Ok(Value::Integer(1)), r);
+    }
+
+    #[test]
+    fn hlen() {
+        let c = create_connection();
+        let r = run_command(&c, &["hset", "foo", "f1", "1", "f2", "2", "f3", "3"]);
+
+        assert_eq!(Ok(Value::Integer(3)), r);
+
+        let r = run_command(&c, &["hset", "foo", "f1", "2", "f4", "2", "f5", "3"]);
+        assert_eq!(Ok(Value::Integer(2)), r);
+
+        let r = run_command(&c, &["hlen", "foo"]);
+        assert_eq!(Ok(Value::Integer(5)), r);
+    }
+
+    #[test]
+    fn hkeys() {
+        let c = create_connection();
+        let r = run_command(&c, &["hset", "foo", "f1", "1"]);
+
+        assert_eq!(Ok(Value::Integer(1)), r);
+
+        let r = run_command(&c, &["hkeys", "foo"]);
+        assert_eq!(Ok(Value::Array(vec![Value::Blob("f1".into()),])), r);
+    }
+
+    #[test]
+    fn hvals() {
+        let c = create_connection();
+        let r = run_command(&c, &["hset", "foo", "f1", "1"]);
+
+        assert_eq!(Ok(Value::Integer(1)), r);
+
+        let r = run_command(&c, &["hvals", "foo"]);
+        assert_eq!(Ok(Value::Array(vec![Value::Blob("1".into()),])), r);
     }
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -2,3 +2,37 @@ pub mod client;
 pub mod hash;
 pub mod key;
 pub mod string;
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        connection::{Connection, Connections},
+        db::Db,
+        dispatcher::Dispatcher,
+        error::Error,
+        value::Value,
+    };
+    use bytes::Bytes;
+    use std::{
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+        ops::Deref,
+        sync::Arc,
+    };
+
+    pub fn create_connection() -> Arc<Connection> {
+        let all_connections = Arc::new(Connections::new());
+        let db = Arc::new(Db::new(1000));
+
+        let client = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+
+        all_connections.new_connection(db.clone(), client)
+    }
+
+    pub fn run_command(conn: &Connection, cmd: &[&str]) -> Result<Value, Error> {
+        let args: Vec<Bytes> = cmd.iter().map(|s| Bytes::from(s.to_string())).collect();
+
+        let handler = Dispatcher::new(&args)?;
+
+        handler.deref().execute(&conn, &args)
+    }
+}

--- a/src/cmd/string.rs
+++ b/src/cmd/string.rs
@@ -67,6 +67,152 @@ pub fn strlen(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
         Value::Blob(x) => Ok((x.len() as i64).into()),
         Value::String(x) => Ok((x.len() as i64).into()),
         Value::Null => Ok(0_i64.into()),
-        _ => Err(Error::WrongType),
+        _ => Ok(Error::WrongType.into()),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        cmd::test::{create_connection, run_command},
+        error::Error,
+        value::Value,
+    };
+
+    #[test]
+    fn incr() {
+        let c = create_connection();
+        let r = run_command(&c, &["incr", "foo"]);
+        assert_eq!(Ok(Value::Integer(1)), r);
+        let r = run_command(&c, &["incr", "foo"]);
+        assert_eq!(Ok(Value::Integer(2)), r);
+
+        let x = run_command(&c, &["get", "foo"]);
+        assert_eq!(Ok(Value::Blob("2".into())), x);
+    }
+
+    #[test]
+    fn incr_do_not_affect_ttl() {
+        let c = create_connection();
+        let r = run_command(&c, &["incr", "foo"]);
+        assert_eq!(Ok(Value::Integer(1)), r);
+
+        let r = run_command(&c, &["expire", "foo", "60"]);
+        assert_eq!(Ok(Value::Integer(1)), r);
+
+        let r = run_command(&c, &["ttl", "foo"]);
+        assert_eq!(Ok(Value::Integer(59)), r);
+
+        let r = run_command(&c, &["incr", "foo"]);
+        assert_eq!(Ok(Value::Integer(2)), r);
+
+        let r = run_command(&c, &["ttl", "foo"]);
+        assert_eq!(Ok(Value::Integer(59)), r);
+    }
+
+    #[test]
+    fn decr() {
+        let c = create_connection();
+        let r = run_command(&c, &["decr", "foo"]);
+        assert_eq!(Ok(Value::Integer(-1)), r);
+        let r = run_command(&c, &["decr", "foo"]);
+        assert_eq!(Ok(Value::Integer(-2)), r);
+        let x = run_command(&c, &["get", "foo"]);
+        assert_eq!(Ok(Value::Blob("-2".into())), x);
+    }
+
+    #[test]
+    fn decr_do_not_affect_ttl() {
+        let c = create_connection();
+        let r = run_command(&c, &["decr", "foo"]);
+        assert_eq!(Ok(Value::Integer(-1)), r);
+
+        let r = run_command(&c, &["expire", "foo", "60"]);
+        assert_eq!(Ok(Value::Integer(1)), r);
+
+        let r = run_command(&c, &["ttl", "foo"]);
+        assert_eq!(Ok(Value::Integer(59)), r);
+
+        let r = run_command(&c, &["decr", "foo"]);
+        assert_eq!(Ok(Value::Integer(-2)), r);
+
+        let r = run_command(&c, &["ttl", "foo"]);
+        assert_eq!(Ok(Value::Integer(59)), r);
+    }
+
+    #[test]
+    fn get_and_set() {
+        let c = create_connection();
+        let x = run_command(&c, &["set", "foo", "bar"]);
+        assert_eq!(Ok(Value::OK), x);
+
+        let x = run_command(&c, &["get", "foo"]);
+        assert_eq!(Ok(Value::Blob("bar".into())), x);
+    }
+
+    #[test]
+    fn getdel() {
+        let c = create_connection();
+        let x = run_command(&c, &["set", "foo", "bar"]);
+        assert_eq!(Ok(Value::OK), x);
+
+        assert_eq!(
+            Ok(Value::Blob("bar".into())),
+            run_command(&c, &["getdel", "foo"])
+        );
+
+        assert_eq!(Ok(Value::Null), run_command(&c, &["get", "foo"]));
+    }
+
+    #[test]
+    fn getset() {
+        let c = create_connection();
+        let x = run_command(&c, &["set", "foo", "bar"]);
+        assert_eq!(Ok(Value::OK), x);
+
+        assert_eq!(
+            Ok(Value::Blob("bar".into())),
+            run_command(&c, &["getset", "foo", "1"])
+        );
+
+        assert_eq!(
+            Ok(Value::Blob("1".into())),
+            run_command(&c, &["get", "foo"])
+        );
+    }
+
+    #[test]
+    fn strlen() {
+        let c = create_connection();
+        let x = run_command(&c, &["set", "foo", "bar"]);
+        assert_eq!(Ok(Value::OK), x);
+
+        let x = run_command(&c, &["strlen", "foo"]);
+        assert_eq!(Ok(Value::Integer(3)), x);
+
+        let x = run_command(&c, &["strlen", "foxxo"]);
+        assert_eq!(Ok(Value::Integer(0)), x);
+    }
+
+    #[test]
+    fn wrong_type() {
+        let c = create_connection();
+        let _ = run_command(&c, &["hset", "xxx", "key", "foo"]);
+        let _ = run_command(&c, &["incr", "foo"]);
+
+        let x = run_command(&c, &["strlen", "xxx"]);
+        assert_eq!(Ok(Error::WrongType.into()), x);
+
+        let x = run_command(&c, &["get", "xxx"]);
+        assert_eq!(Ok(Error::WrongType.into()), x);
+
+        let x = run_command(&c, &["get", "xxx"]);
+        assert_eq!(Ok(Error::WrongType.into()), x);
+
+        let x = run_command(&c, &["mget", "xxx", "foo"]);
+        assert_eq!(
+            Ok(Value::Array(vec![Value::Null, Value::Blob("1".into()),])),
+            x
+        );
     }
 }


### PR DESCRIPTION
Write unit tests, the unit tests will create a new dummy connection and
will let the test function to execute commands directly.

This is the first and fast tests, for sanity checks. The ultimate goal
is to run the tcl tests from the redis projects as we are aiming to be
compatible.

Also improved issued found while running the unit tests. For instance
the way returned data are cloned is improved. It is now harder to clone
complex values (Hashes, set). It is not longer possible to read complex
values through `DB.get`, `DB.get_map_or` should be used instead.