### PR TITLE
Add checksum::Ref

### DIFF
--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -131,7 +131,7 @@ pub async fn linsert(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> 
         &args[1],
         |v| match v {
             Value::List(x) => {
-                let pivot = checksum::Value::new(args[3].clone());
+                let pivot = checksum::Ref::new(&args[3]);
                 let mut x = x.write();
                 let mut found = false;
 
@@ -255,7 +255,7 @@ pub async fn lpop(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
 
 pub async fn lpos(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
     let mut index = 3;
-    let element = checksum::Value::new(args[2].clone());
+    let element = checksum::Ref::new(&args[2]);
     let rank = if check_arg!(args, index, "RANK") {
         index += 2;
         Some(bytes_to_number::<usize>(&args[index - 1])?)
@@ -395,7 +395,7 @@ pub async fn lrem(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
         &args[1],
         |v| match v {
             Value::List(x) => {
-                let element = checksum::Value::new(args[3].clone());
+                let element = checksum::Ref::new(&args[3]);
                 let limit: i64 = bytes_to_number(&args[2])?;
                 let mut x = x.write();
 
@@ -412,9 +412,7 @@ pub async fn lrem(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
                 for i in 0..len {
                     let i = if is_reverse { len - 1 - i } else { i };
 
-                    println!("{}", i);
                     if let Some(value) = x.get(i) {
-                        println!("{} {:?} {:?}", i, *value, element);
                         if *value == element {
                             keep[i] = false;
                             removed += 1;

--- a/src/value/checksum.rs
+++ b/src/value/checksum.rs
@@ -1,6 +1,29 @@
 use crate::value;
 use bytes::Bytes;
-use crc32fast::Hasher;
+use crc32fast::Hasher as Crc32Hasher;
+use std::hash::{Hash, Hasher};
+
+fn calculate_checksum(bytes: &Bytes) -> Option<u32> {
+        if bytes.len() < 1024 {
+            None
+        } else {
+            let mut hasher = Crc32Hasher::new();
+            hasher.update(bytes);
+            Some(hasher.finalize())
+        }
+}
+
+pub struct Ref<'a> {
+    bytes: &'a Bytes,
+    checksum: Option<u32>,
+}
+
+impl<'a> Ref<'a> {
+    pub fn new(bytes: &'a Bytes) -> Self {
+        let checksum = calculate_checksum(bytes);
+        Self { bytes, checksum }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct Value {
@@ -10,7 +33,7 @@ pub struct Value {
 
 impl Value {
     pub fn new(bytes: Bytes) -> Self {
-        let checksum = Self::calculate_checksum(&bytes);
+        let checksum = calculate_checksum(&bytes);
         Self { bytes, checksum }
     }
 
@@ -21,20 +44,30 @@ impl Value {
     pub fn has_checksum(&self) -> bool {
         self.checksum.is_some()
     }
+}
 
-    fn calculate_checksum(bytes: &Bytes) -> Option<u32> {
-        if bytes.len() < 1024 {
-            None
-        } else {
-            let mut hasher = Hasher::new();
-            hasher.update(bytes);
-            Some(hasher.finalize())
-        }
+impl Hash for Value {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.bytes.hash(state);
     }
 }
 
 impl PartialEq for Value {
     fn eq(&self, other: &Value) -> bool {
+        if self.checksum == other.checksum && self.bytes.len() == other.bytes.len() {
+            // The data have the same checksum now perform a more extensive
+            // comparision
+            return self.bytes.eq(&other.bytes);
+        }
+
+        false
+    }
+}
+
+impl Eq for Value {}
+
+impl<'a> PartialEq<Ref<'a>> for Value {
+    fn eq(&self, other: &Ref) -> bool {
         if self.checksum == other.checksum && self.bytes.len() == other.bytes.len() {
             // The data have the same checksum now perform a more extensive
             // comparision


### PR DESCRIPTION
The idea behind this struct is to avoid cloning the Bytes which it
represents for quick comparisons, instead a reference of Bytes is
referenced in the struct.