### PR TITLE
Remove all unwrap() from the codebase

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 redis-zero-protocol-parser = {path = "redis-protocol-parser"}
 tokio={version="1", features = ["full", "tracing"] }
+parking_lot="^0.11"
 tokio-util={version="^0.6", features = ["full"] }
 async-trait = "0.1.50"
 crc32fast="^1.2"

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -35,11 +35,7 @@ fn remove_element(
                     }
                 }
 
-                let ret: Vec<Value> = ret
-                    .iter()
-                    .filter(|v| v.is_some())
-                    .map(|x| x.as_ref().unwrap().clone_value())
-                    .collect();
+                let ret: Vec<Value> = ret.iter().flatten().map(|m| m.clone_value()).collect();
 
                 Ok(if ret.is_empty() {
                     Value::Null

--- a/src/cmd/transaction.rs
+++ b/src/cmd/transaction.rs
@@ -192,11 +192,10 @@ mod test {
 
     fn get_keys(args: &[&str]) -> Vec<Bytes> {
         let args: Vec<Bytes> = args.iter().map(|s| Bytes::from(s.to_string())).collect();
-        Dispatcher::new(&args)
-            .unwrap()
-            .get_keys(&args)
-            .iter()
-            .map(|k| (*k).clone())
-            .collect()
+        if let Ok(cmd) = Dispatcher::new(&args) {
+            cmd.get_keys(&args).iter().map(|k| (*k).clone()).collect()
+        } else {
+            vec![]
+        }
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -78,9 +78,9 @@ macro_rules! dispatcher {
 
                     fn check_number_args(&self, n: usize) -> bool {
                         if ($min_args >= 0) {
-                            n == ($min_args as i32).try_into().unwrap()
+                            n == ($min_args as i32).try_into().unwrap_or(0)
                         } else {
-                            let s: usize = ($min_args as i32).abs().try_into().unwrap();
+                            let s: usize = ($min_args as i32).abs().try_into().unwrap_or(0);
                             n >= s
                         }
                     }

--- a/src/value/locked.rs
+++ b/src/value/locked.rs
@@ -1,17 +1,17 @@
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 #[derive(Debug)]
 pub struct Value<T: Clone + PartialEq>(pub RwLock<T>);
 
 impl<T: Clone + PartialEq> Clone for Value<T> {
     fn clone(&self) -> Self {
-        Self(RwLock::new(self.0.read().unwrap().clone()))
+        Self(RwLock::new(self.0.read().clone()))
     }
 }
 
 impl<T: PartialEq + Clone> PartialEq for Value<T> {
     fn eq(&self, other: &Value<T>) -> bool {
-        self.0.read().unwrap().eq(&other.0.read().unwrap())
+        self.0.read().eq(&other.0.read())
     }
 }
 
@@ -21,11 +21,11 @@ impl<T: PartialEq + Clone> Value<T> {
     }
 
     pub fn write(&self) -> RwLockWriteGuard<'_, T> {
-        self.0.write().unwrap()
+        self.0.write()
     }
 
     pub fn read(&self) -> RwLockReadGuard<'_, T> {
-        self.0.read().unwrap()
+        self.0.read()
     }
 }
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -101,9 +101,7 @@ impl<'a> From<&ParsedValue<'a>> for Value {
         match value {
             ParsedValue::String(x) => Self::String((*x).to_string()),
             ParsedValue::Blob(x) => Self::Blob(Bytes::copy_from_slice(*x)),
-            ParsedValue::Array(x) => {
-                Self::Array(x.iter().map(|x| Value::try_from(x).unwrap()).collect())
-            }
+            ParsedValue::Array(x) => Self::Array(x.iter().map(|x| x.into()).collect()),
             ParsedValue::Boolean(x) => Self::Boolean(*x),
             ParsedValue::BigInteger(x) => Self::BigInteger(*x),
             ParsedValue::Integer(x) => Self::Integer(*x),


### PR DESCRIPTION
* Removed all `unwrap()`, from tests and macros.
* Replaced RwLock and Mutex from the native library to use
  `parking_lot`, it is supposed to be faster and no `unwrap` needed to
  use it.