### PR TITLE
Optimized dispatcher

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -19,7 +19,6 @@ mod test {
     use bytes::Bytes;
     use std::{
         net::{IpAddr, Ipv4Addr, SocketAddr},
-        ops::Deref,
         sync::Arc,
     };
     use tokio::sync::mpsc::UnboundedReceiver;
@@ -55,8 +54,9 @@ mod test {
     pub async fn run_command(conn: &Connection, cmd: &[&str]) -> Result<Value, Error> {
         let args: Vec<Bytes> = cmd.iter().map(|s| Bytes::from(s.to_string())).collect();
 
-        let handler = Dispatcher::new(&args)?;
+        let dispatcher = Dispatcher::new();
+        let handler = dispatcher.get_handler(&args)?;
 
-        handler.deref().execute(conn, &args).await
+        handler.execute(conn, &args).await
     }
 }

--- a/src/cmd/transaction.rs
+++ b/src/cmd/transaction.rs
@@ -1,6 +1,5 @@
 use crate::{
     connection::{Connection, ConnectionStatus},
-    dispatcher::Dispatcher,
     error::Error,
     value::Value,
 };
@@ -33,7 +32,7 @@ pub async fn exec(conn: &Connection, _: &[Bytes]) -> Result<Value, Error> {
 
     if let Some(commands) = conn.get_queue_commands() {
         for args in commands.iter() {
-            let result = match Dispatcher::new(args) {
+            let result = match conn.all_connections().get_dispatcher().get_handler(args) {
                 Ok(handler) => handler
                     .execute(conn, args)
                     .await
@@ -195,7 +194,8 @@ mod test {
 
     fn get_keys(args: &[&str]) -> Vec<Bytes> {
         let args: Vec<Bytes> = args.iter().map(|s| Bytes::from(s.to_string())).collect();
-        if let Ok(cmd) = Dispatcher::new(&args) {
+        let d = Dispatcher::new();
+        if let Ok(cmd) = d.get_handler(&args) {
             cmd.get_keys(&args).iter().map(|k| (*k).clone()).collect()
         } else {
             vec![]

--- a/src/connection/connections.rs
+++ b/src/connection/connections.rs
@@ -1,5 +1,5 @@
 use super::{pubsub_connection::PubsubClient, pubsub_server::Pubsub, Connection, ConnectionInfo};
-use crate::{db::Db, value::Value};
+use crate::{db::Db, dispatcher::Dispatcher, value::Value};
 use parking_lot::RwLock;
 use std::{collections::BTreeMap, net::SocketAddr, sync::Arc};
 
@@ -10,6 +10,7 @@ pub struct Connections {
     connections: RwLock<BTreeMap<u128, Arc<Connection>>>,
     db: Arc<Db>,
     pubsub: Arc<Pubsub>,
+    dispatcher: Arc<Dispatcher>,
     counter: RwLock<u128>,
 }
 
@@ -19,6 +20,7 @@ impl Connections {
             counter: RwLock::new(0),
             db,
             pubsub: Arc::new(Pubsub::new()),
+            dispatcher: Arc::new(Dispatcher::new()),
             connections: RwLock::new(BTreeMap::new()),
         }
     }
@@ -26,6 +28,10 @@ impl Connections {
     #[allow(dead_code)]
     pub fn db(&self) -> Arc<Db> {
         self.db.clone()
+    }
+
+    pub fn get_dispatcher(&self) -> Arc<Dispatcher> {
+        self.dispatcher.clone()
     }
 
     pub fn pubsub(&self) -> Arc<Pubsub> {


### PR DESCRIPTION
On each parsed command send by clients a new dispatcher object would
have been created to be thrown away right when the command has been
executed. This was a bit suboptimal, although easier to implement.

This MR creates a single dispatcher object and will return a reference
to the handler function based on the command to be executed. Having a
single object, shared for all connections is far more efficient *and*
also required to gather metrics.