### PR TITLE
Adding missing commands into the string data-types

### DIFF
--- a/src/cmd/hash.rs
+++ b/src/cmd/hash.rs
@@ -125,7 +125,7 @@ pub async fn hincrby<
             #[allow(clippy::mutable_key_type)]
             let mut h = HashMap::new();
             h.insert(args[2].clone(), incr_by.to_string().into());
-            conn.db().set(&args[1], h.into(), None, true);
+            conn.db().set(&args[1], h.into(), None);
             Ok(incr_by.into())
         },
     )?;
@@ -286,7 +286,7 @@ pub async fn hset(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
                 h.insert(args[i].clone(), args[i + 1].clone());
             }
             let len = h.len();
-            conn.db().set(&args[1], h.into(), None, true);
+            conn.db().set(&args[1], h.into(), None);
             Ok(len.into())
         },
     )?;
@@ -322,7 +322,7 @@ pub async fn hsetnx(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
                 h.insert(args[i].clone(), args[i + 1].clone());
             }
             let len = h.len();
-            conn.db().set(&args[1], h.into(), None, true);
+            conn.db().set(&args[1], h.into(), None);
             Ok(len.into())
         },
     )?;

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -259,7 +259,7 @@ pub async fn lmove(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
                         let ret = element.clone_value();
                         let mut h = VecDeque::new();
                         h.push_front(element);
-                        conn.db().set(&args[2], h.into(), None, true);
+                        conn.db().set(&args[2], h.into(), None);
                         Ok(ret)
                     } else {
                         Ok(Value::Null)
@@ -404,7 +404,7 @@ pub async fn lpush(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
             }
 
             let len = h.len();
-            conn.db().set(&args[1], h.into(), None, true);
+            conn.db().set(&args[1], h.into(), None);
             Ok(len.into())
         },
     )?;
@@ -635,7 +635,7 @@ pub async fn rpush(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
             }
 
             let len = h.len();
-            conn.db().set(&args[1], h.into(), None, true);
+            conn.db().set(&args[1], h.into(), None);
             Ok(len.into())
         },
     )?;

--- a/src/cmd/set.rs
+++ b/src/cmd/set.rs
@@ -16,7 +16,7 @@ fn store(conn: &Connection, key: &Bytes, values: &[Value]) -> i64 {
             }
         }
     }
-    conn.db().set(key, x.into(), None, true);
+    conn.db().set(key, x.into(), None);
     len
 }
 
@@ -95,7 +95,7 @@ pub async fn sadd(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
                 }
             }
 
-            conn.db().set(&args[1], x.into(), None, true);
+            conn.db().set(&args[1], x.into(), None);
 
             Ok(len.into())
         },
@@ -288,7 +288,7 @@ pub async fn smove(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
                         #[allow(clippy::mutable_key_type)]
                         let mut x = HashSet::new();
                         x.insert(args[3].clone());
-                        conn.db().set(&args[2], x.into(), None, true);
+                        conn.db().set(&args[2], x.into(), None);
                         Ok(1.into())
                     },
                 )

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -214,6 +214,18 @@ macro_rules! check_arg {
     }}
 }
 
+/// Reads an argument index. If the index is not provided an Err(Error:Syntax)
+/// is thrown
+#[macro_export]
+macro_rules! try_get_arg {
+    {$args: tt, $pos: tt} => {{
+        match $args.get($pos) {
+            Some(bytes) => bytes,
+            None => return Err(Error::Syntax),
+        }
+    }}
+}
+
 /// Convert a stream to a Bytes
 #[macro_export]
 macro_rules! bytes {


### PR DESCRIPTION
Commands:

* [x] APPEND
* [x] DECR
* [x] DECRBY
* [x] GET
* [x] GETDEL
* [x] GETEX
* [x] GETRANGE
* [x] GETSET
* [x] INCR
* [x] INCRBY
* [x] INCRBYFLOAT
* [x] MGET
* [x] MSET
* [x] MSETNX
* [x] PSETEX
* [x] SET
* [x] SETEX
* [x] SETNX
* [ ] SETRANGE
* [x] STRLEN
* [x] SUBSTR