### PR TITLE
Fixed bug with PERSIST

### DIFF
--- a/src/db/expiration.rs
+++ b/src/db/expiration.rs
@@ -46,6 +46,10 @@ impl ExpirationDb {
         self.next_id += 1;
     }
 
+    pub fn has(&self, key: &Bytes) -> bool {
+        self.keys.get(key).is_some()
+    }
+
     pub fn remove(&mut self, key: &Bytes) -> bool {
         if let Some(prev) = self.keys.remove(key) {
             // Another key with expiration is already known, it has


### PR DESCRIPTION
PERSIST operation did not remove the key from the purge process.
Microredis does have a dedicated structure to watch keys with
expirations in it.

Previous this commit if a key had any expiration and then this
expiration was removed with the PERSIST command, the expiration would be
removed from the key-itself, but the purge process (which is a
background process) wouldn't know about this change removing the key in
due time.

This commit notifies of PERSIST changes to the purge process.