### PR TITLE
Use BytesMut for Value::Blob instead Bytes

### DIFF
--- a/src/cmd/client.rs
+++ b/src/cmd/client.rs
@@ -50,7 +50,7 @@ pub async fn client(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
 /// Documentation:
 ///  * <https://redis.io/commands/echo>
 pub async fn echo(_conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    Ok(Value::Blob(args[1].to_owned()))
+    Ok(Value::new(&args[1]))
 }
 
 /// "ping" command handler
@@ -60,7 +60,7 @@ pub async fn echo(_conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
 pub async fn ping(_conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
     match args.len() {
         1 => Ok(Value::String("PONG".to_owned())),
-        2 => Ok(Value::Blob(args[1].to_owned())),
+        2 => Ok(Value::new(&args[1])),
         _ => Err(Error::InvalidArgsCount("ping".to_owned())),
     }
 }

--- a/src/cmd/hash.rs
+++ b/src/cmd/hash.rs
@@ -62,7 +62,7 @@ pub async fn hget(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
         &args[1],
         |v| match v {
             Value::Hash(h) => Ok(if let Some(v) = h.read().get(&args[2]) {
-                Value::Blob(v.clone())
+                Value::new(&v)
             } else {
                 Value::Null
             }),
@@ -82,8 +82,8 @@ pub async fn hgetall(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> 
                 let mut ret = vec![];
 
                 for (key, value) in h.read().iter() {
-                    ret.push(Value::Blob(key.clone()));
-                    ret.push(Value::Blob(value.clone()));
+                    ret.push(Value::new(&key));
+                    ret.push(Value::new(&value));
                 }
 
                 Ok(ret.into())
@@ -144,7 +144,7 @@ pub async fn hkeys(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
                 let mut ret = vec![];
 
                 for key in h.read().keys() {
-                    ret.push(Value::Blob(key.clone()));
+                    ret.push(Value::new(&key));
                 }
 
                 Ok(ret.into())
@@ -179,7 +179,7 @@ pub async fn hmget(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
                     .iter()
                     .map(|key| {
                         if let Some(value) = h.get(key) {
-                            Value::Blob(value.clone())
+                            Value::new(&value)
                         } else {
                             Value::Null
                         }
@@ -234,17 +234,17 @@ pub async fn hrandfield(conn: &Connection, args: &[Bytes]) -> Result<Value, Erro
                 i = 0;
                 for val in rand_sorted.values() {
                     if single {
-                        return Ok(Value::Blob(val.0.clone()));
+                        return Ok(Value::new(&val.0));
                     }
 
                     if i == count {
                         break;
                     }
 
-                    ret.push(Value::Blob(val.0.clone()));
+                    ret.push(Value::new(&val.0));
 
                     if with_values {
-                        ret.push(Value::Blob(val.1.clone()));
+                        ret.push(Value::new(&val.1));
                     }
 
                     i += 1;
@@ -360,7 +360,7 @@ pub async fn hvals(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
                 let mut ret = vec![];
 
                 for value in h.read().values() {
-                    ret.push(Value::Blob(value.clone()));
+                    ret.push(Value::new(&value));
                 }
 
                 Ok(ret.into())

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -63,14 +63,15 @@ fn remove_element(
 /// popped from the head of the first list that is non-empty, with the given keys being checked in
 /// the order that they are given.
 pub async fn blpop(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    let timeout = Instant::now() + Duration::from_secs(bytes_to_number(&args[args.len() - 1])?);
+    let timeout =
+        Instant::now() + Duration::from_secs(bytes_to_number::<u64>(&args[args.len() - 1])?);
     let len = args.len() - 1;
 
     loop {
         for key in args[1..len].iter() {
             match remove_element(conn, key, 0, true)? {
                 Value::Null => (),
-                n => return Ok(vec![Value::Blob(key.clone()), n].into()),
+                n => return Ok(vec![Value::new(&key), n].into()),
             };
         }
 
@@ -89,14 +90,15 @@ pub async fn blpop(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
 /// popped from the tail of the first list that is non-empty, with the given keys being checked in
 /// the order that they are given.
 pub async fn brpop(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    let timeout = Instant::now() + Duration::from_secs(bytes_to_number(&args[args.len() - 1])?);
+    let timeout =
+        Instant::now() + Duration::from_secs(bytes_to_number::<u64>(&args[args.len() - 1])?);
     let len = args.len() - 1;
 
     loop {
         for key in args[1..len].iter() {
             match remove_element(conn, key, 0, false)? {
                 Value::Null => (),
-                n => return Ok(vec![Value::Blob(key.clone()), n].into()),
+                n => return Ok(vec![Value::new(&key), n].into()),
             };
         }
 

--- a/src/cmd/pubsub.rs
+++ b/src/cmd/pubsub.rs
@@ -15,7 +15,7 @@ pub async fn pubsub(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
             conn.pubsub()
                 .channels()
                 .iter()
-                .map(|v| Value::Blob(v.clone()))
+                .map(|v| Value::new(&v))
                 .collect(),
         )),
         "help" => Ok(Value::Array(vec![
@@ -29,7 +29,7 @@ pub async fn pubsub(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
             .pubsub()
             .get_number_of_subscribers(&args[2..])
             .iter()
-            .map(|(channel, subs)| vec![Value::Blob(channel.clone()), (*subs).into()])
+            .map(|(channel, subs)| vec![Value::new(&channel), (*subs).into()])
             .flatten()
             .collect::<Vec<Value>>()
             .into()),

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -50,7 +50,7 @@ pub async fn command(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> 
                 command
                     .get_keys(args)
                     .iter()
-                    .map(|key| Value::Blob((*key).clone()))
+                    .map(|key| Value::new(*key))
                     .collect(),
             ))
         }

--- a/src/connection/pubsub_server.rs
+++ b/src/connection/pubsub_server.rs
@@ -79,7 +79,7 @@ impl Pubsub {
             let _ = conn.pubsub_client().sender().try_send(
                 vec![
                     "psubscribe".into(),
-                    Value::Blob(bytes_channel.clone()),
+                    Value::new(&bytes_channel),
                     conn.pubsub_client().new_psubscription(&channel).into(),
                 ]
                 .into(),
@@ -99,8 +99,8 @@ impl Pubsub {
                 if sender
                     .try_send(Value::Array(vec![
                         "message".into(),
-                        Value::Blob(channel.clone()),
-                        Value::Blob(message.clone()),
+                        Value::new(&channel),
+                        Value::new(&message),
                     ]))
                     .is_ok()
                 {
@@ -120,8 +120,8 @@ impl Pubsub {
                 let _ = sub.try_send(Value::Array(vec![
                     "pmessage".into(),
                     pattern.as_str().into(),
-                    Value::Blob(channel.clone()),
-                    Value::Blob(message.clone()),
+                    Value::new(channel),
+                    Value::new(message),
                 ]));
                 i += 1;
             }
@@ -175,7 +175,7 @@ impl Pubsub {
                 let _ = conn.pubsub_client().sender().try_send(
                     vec![
                         "subscribe".into(),
-                        Value::Blob(channel.clone()),
+                        Value::new(&channel),
                         conn.pubsub_client().new_subscription(channel).into(),
                     ]
                     .into(),
@@ -196,7 +196,7 @@ impl Pubsub {
                     if let Some(sender) = subs.remove(&conn_id) {
                         let _ = sender.try_send(Value::Array(vec![
                             "unsubscribe".into(),
-                            Value::Blob(channel.clone()),
+                            Value::new(&channel),
                             1.into(),
                         ]));
                         removed += 1;

--- a/src/db/entry.rs
+++ b/src/db/entry.rs
@@ -99,6 +99,8 @@ impl Entry {
         )
     }
 
+    /// Clone a value. If the value is not clonable an error is Value::Error is
+    /// returned instead
     pub fn clone_value(&self) -> Value {
         if self.is_clonable() {
             self.value.clone()

--- a/src/db/expiration.rs
+++ b/src/db/expiration.rs
@@ -130,10 +130,10 @@ mod test {
     fn get_expiration() {
         let mut db = ExpirationDb::new();
         let keys = vec![
-            (bytes!(b"hix"), Instant::now() + Duration::from_secs(15)),
-            (bytes!(b"key"), Instant::now() + Duration::from_secs(2)),
-            (bytes!(b"bar"), Instant::now() + Duration::from_secs(3)),
-            (bytes!(b"hi"), Instant::now() + Duration::from_secs(3)),
+            ("hix".into(), Instant::now() + Duration::from_secs(15)),
+            ("key".into(), Instant::now() + Duration::from_secs(2)),
+            ("bar".into(), Instant::now() + Duration::from_secs(3)),
+            ("hi".into(), Instant::now() + Duration::from_secs(3)),
         ];
 
         keys.iter()
@@ -164,15 +164,15 @@ mod test {
     pub fn remove() {
         let mut db = ExpirationDb::new();
         let keys = vec![
-            (bytes!(b"hix"), Instant::now() + Duration::from_secs(15)),
-            (bytes!(b"key"), Instant::now() + Duration::from_secs(2)),
-            (bytes!(b"bar"), Instant::now() + Duration::from_secs(3)),
-            (bytes!(b"hi"), Instant::now() + Duration::from_secs(3)),
+            ("hix".into(), Instant::now() + Duration::from_secs(15)),
+            ("key".into(), Instant::now() + Duration::from_secs(2)),
+            ("bar".into(), Instant::now() + Duration::from_secs(3)),
+            ("hi".into(), Instant::now() + Duration::from_secs(3)),
         ];
 
         keys.iter()
             .map(|v| {
-                db.add(&v.0, v.1);
+                db.add(&(v.0), v.1);
             })
             .for_each(drop);
 

--- a/src/dispatcher/mod.rs
+++ b/src/dispatcher/mod.rs
@@ -760,6 +760,15 @@ dispatcher! {
             1,
             true,
         },
+        setrange {
+            cmd::string::setrange,
+            [Flag::Write],
+            4,
+            1,
+            1,
+            1,
+            true,
+        }
     },
     connection {
         client {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -230,6 +230,6 @@ macro_rules! try_get_arg {
 #[macro_export]
 macro_rules! bytes {
     ($content:tt) => {
-        Bytes::from(&$content[..])
+        (&$content[..]).into()
     };
 }

--- a/src/value/checksum.rs
+++ b/src/value/checksum.rs
@@ -52,7 +52,7 @@ impl Value {
 
     /// Clone the underlying value
     pub fn clone_value(&self) -> value::Value {
-        value::Value::Blob(self.bytes.clone())
+        value::Value::new(&self.bytes)
     }
 
     /// Whether it has a checksum or not


### PR DESCRIPTION
BytesMut is needed in order to implement an efficient way to change the
stored values. Right now the whole value has to be replaced with a new
value.

That is particular inefficient for APPEND and SETRANGE.

Commands

* [x] APPEND
* [x] SETRANGE