### PR TITLE
Improve blocking tasks

### DIFF
--- a/src/cmd/client.rs
+++ b/src/cmd/client.rs
@@ -59,6 +59,11 @@ pub async fn client(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
             };
 
             Ok(if other_conn.unblock(reason) {
+                other_conn.append_response(if reason == UnblockReason::Error {
+                    Error::UnblockByError.into()
+                } else {
+                    Value::Null
+                });
                 1.into()
             } else {
                 0.into()

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -423,8 +423,6 @@ start_server {
 
       r rpush list1{t} foo
 
-      after 50
-
       assert_equal {} [r lrange list1{t} 0 -1]
       assert_equal {} [r lrange list2{t} 0 -1]
       assert_equal {foo} [r lrange list3{t} 0 -1]
@@ -484,7 +482,6 @@ start_server {
         $watching_client get somekey{t}
         $watching_client read
         r lpush srclist{t} element
-        after 50
         $watching_client exec
         $watching_client read
     } {}


### PR DESCRIPTION
Introduce a generic way to spawn blocking tasks, adding an optional
timeout option and a retry mechanism.

The spawned task will subscribe to a set of keys and will be awaken
everytime the data version changes in any of the watched keys. The
worker function will return true or false, false meaning they want to be
rescheduled again.

This mechanism will improve CPU usage on current approach which is
sleep/retry every few milliseconds, which is suboptimal to say the
least.

Fixes #52 