### PR TITLE
Delay db insert to avoid deadlock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: test
+    - name: prepare
       run: |
         rustup component add clippy
         sudo apt-get install tcl8.6 tclx
-        make ci
+    - name: Fmt
+      run: make fmt
+    - name: Clippy
+      run: make clippy
+    - name: Unit test
+      run: make unit-test
+    - name: Test
+      run: make test
+

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 fmt:
-	cargo fmt
+	cargo fmt --check
 clippy:
 	cargo clippy --release
 build:


### PR DESCRIPTION
When using `get_map_or` it is not allowed to change the database state
inside the callback or it may endup in a database deadlock.

This PR fixes that situation for `lmove`