### PR TITLE
Better memory managment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,9 +137,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cfg-if"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytes = "1"
+bytes = "1.4"
 byteorder = "1.2.2"
 redis-zero-protocol-parser = "^0.3"
 redis-config-parser = {path = "redis-config-parser"}

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,30 @@ build:
 	cargo build --release
 test-single: build
 	./runtest  --clients 1 \
-		--single unit/other \
+		--skipunit unit/dump \
+		--skipunit unit/auth \
+		--skipunit unit/protocol \
+		--skipunit unit/scan \
+		--skipunit unit/info \
+		--skipunit unit/type/zset \
+		--skipunit unit/bitops \
+		--skipunit unit/type/stream \
+		--skipunit unit/type/stream-cgroups \
+		--skipunit unit/sort \
+		--skipunit unit/aofrw \
+		--skipunit unit/acl \
+		--skipunit unit/latency-monitor \
+		--skipunit unit/slowlog \
+		--skipunit unit/scripting \
+		--skipunit unit/introspection \
+		--skipunit unit/introspection-2 \
+		--skipunit unit/bitfield \
+		--skipunit unit/geo \
+		--skipunit unit/pause \
+		--skipunit unit/hyperloglog \
+		--skipunit unit/lazyfree \
+		--skipunit unit/tracking \
+		--skipunit unit/querybuf \
 		--ignore-encoding \
 		--tags -needs:repl \
 		--tags -leaks \

--- a/redis-config-parser/src/parser.rs
+++ b/redis-config-parser/src/parser.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum Error {
     /// The data is incomplete. This it not an error per-se, but rather a
     /// mechanism to let the caller know they should keep buffering data before
@@ -8,14 +8,14 @@ pub enum Error {
     Partial,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum Args<'a> {
     None,
     Single(Cow<'a, str>),
     Multiple(Vec<Cow<'a, str>>),
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct ConfigValue<'a> {
     pub name: Cow<'a, str>,
     pub args: Args<'a>,
@@ -59,7 +59,7 @@ macro_rules! read_until {
 
 pub fn parse(bytes: &'_ [u8]) -> Result<(&'_ [u8], ConfigValue<'_>), Error> {
     let bytes = skip!(bytes, vec![b' ', b'\t', b'\r', b'\n']);
-    let bytes = if bytes.get(0) == Some(&b'#') {
+    let bytes = if bytes.first() == Some(&b'#') {
         // The entire line is a comment, skip the whole line
         let (bytes, _) = read_until!(bytes, vec![b'\n']);
         skip!(bytes, vec![b' ', b'\t', b'\r', b'\n'])

--- a/src/cmd/client.rs
+++ b/src/cmd/client.rs
@@ -102,7 +102,7 @@ pub async fn ping(conn: &Connection, mut args: VecDeque<Bytes>) -> Result<Value,
     if conn.status() == ConnectionStatus::Pubsub {
         return Ok(Value::Array(vec![
             "pong".into(),
-            Value::Blob(args.pop_front().ok_or(Error::Syntax)?),
+            args.pop_front().map(|p| Value::Blob(p)).unwrap_or_default(),
         ]));
     }
     match args.len() {

--- a/src/cmd/metrics.rs
+++ b/src/cmd/metrics.rs
@@ -1,19 +1,21 @@
 //! # Metrics command handlers
+use std::collections::VecDeque;
+
 use crate::{connection::Connection, error::Error, value::Value};
 use bytes::Bytes;
 
 /// Dumps metrics from commands. If no argument is passed all commands' metrics are dump.
 ///
 /// The metrics are serialized as JSON.
-pub async fn metrics(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
+pub async fn metrics(conn: &Connection, args: VecDeque<Bytes>) -> Result<Value, Error> {
     let dispatcher = conn.all_connections().get_dispatcher();
     let mut result: Vec<Value> = vec![];
     let commands = if args.len() == 1 {
         dispatcher.get_all_commands()
     } else {
         let mut commands = vec![];
-        for command in &(args[1..]) {
-            let command = String::from_utf8_lossy(command);
+        for command in args.into_iter() {
+            let command = String::from_utf8_lossy(&command);
             commands.push(dispatcher.get_handler_for_command(&command)?);
         }
         commands

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -33,6 +33,7 @@ mod test {
     };
     use bytes::Bytes;
     use std::{
+        collections::VecDeque,
         net::{IpAddr, Ipv4Addr, SocketAddr},
         sync::Arc,
     };
@@ -76,10 +77,10 @@ mod test {
     }
 
     pub async fn run_command(conn: &Connection, cmd: &[&str]) -> Result<Value, Error> {
-        let args: Vec<Bytes> = cmd.iter().map(|s| Bytes::from(s.to_string())).collect();
+        let args: VecDeque<Bytes> = cmd.iter().map(|s| Bytes::from(s.to_string())).collect();
 
         let dispatcher = Dispatcher::new();
-        dispatcher.execute(conn, &args).await
+        dispatcher.execute(conn, args).await
     }
 
     #[tokio::test]

--- a/src/cmd/set.rs
+++ b/src/cmd/set.rs
@@ -363,8 +363,10 @@ pub async fn smove(conn: &Connection, mut args: VecDeque<Bytes>) -> Result<Value
         || Ok(0.into()),
     )?;
 
-    conn.db().bump_version(&source);
-    conn.db().bump_version(&destination);
+    if result == Value::Integer(1) {
+        conn.db().bump_version(&source);
+        conn.db().bump_version(&destination);
+    }
 
     Ok(result)
 }

--- a/src/cmd/string.rs
+++ b/src/cmd/string.rs
@@ -11,7 +11,9 @@ use crate::{
 use bytes::Bytes;
 use std::{
     cmp::min,
+    collections::VecDeque,
     convert::TryInto,
+    f32::consts::E,
     ops::{Bound, Neg},
 };
 use tokio::time::Duration;
@@ -19,32 +21,32 @@ use tokio::time::Duration;
 /// If key already exists and is a string, this command appends the value at the
 /// end of the string. If key does not exist it is created and set as an empty
 /// string, so APPEND will be similar to SET in this special case.
-pub async fn append(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    conn.db().append(&args[1], &args[2])
+pub async fn append(conn: &Connection, args: VecDeque<Bytes>) -> Result<Value, Error> {
+    conn.db().append(&args[0], &args[1])
 }
 
 /// Increments the number stored at key by one. If the key does not exist, it is set to 0 before
 /// performing the operation. An error is returned if the key contains a value of the wrong type or
 /// contains a string that can not be represented as integer. This operation is limited to 64 bit
 /// signed integers.
-pub async fn incr(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    conn.db().incr(&args[1], 1_i64).map(|n| n.into())
+pub async fn incr(conn: &Connection, args: VecDeque<Bytes>) -> Result<Value, Error> {
+    conn.db().incr(&args[0], 1_i64).map(|n| n.into())
 }
 
 /// Increments the number stored at key by increment. If the key does not exist, it is set to 0
 /// before performing the operation. An error is returned if the key contains a value of the wrong
 /// type or contains a string that can not be represented as integer. This operation is limited to
 /// 64 bit signed integers.
-pub async fn incr_by(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    let by: i64 = bytes_to_number(&args[2])?;
-    conn.db().incr(&args[1], by).map(|n| n.into())
+pub async fn incr_by(conn: &Connection, args: VecDeque<Bytes>) -> Result<Value, Error> {
+    let by: i64 = bytes_to_number(&args[1])?;
+    conn.db().incr(&args[0], by).map(|n| n.into())
 }
 
 /// Increment the string representing a floating point number stored at key by the specified
 /// increment. By using a negative increment value, the result is that the value stored at the key
 /// is decremented (by the obvious properties of addition). If the key does not exist, it is set to
 /// 0 before performing the operation.
-pub async fn incr_by_float(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
+pub async fn incr_by_float(conn: &Connection, args: VecDeque<Bytes>) -> Result<Value, Error> {
     let by = bytes_to_number::<Float>(&args[2])?;
     if by.is_infinite() || by.is_nan() {
         return Err(Error::IncrByInfOrNan);
@@ -62,28 +64,28 @@ pub async fn incr_by_float(conn: &Connection, args: &[Bytes]) -> Result<Value, E
 /// performing the operation. An error is returned if the key contains a value of the wrong type or
 /// contains a string that can not be represented as integer. This operation is limited to 64 bit
 /// signed integers.
-pub async fn decr(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    conn.db().incr(&args[1], -1_i64).map(|n| n.into())
+pub async fn decr(conn: &Connection, args: VecDeque<Bytes>) -> Result<Value, Error> {
+    conn.db().incr(&args[0], -1_i64).map(|n| n.into())
 }
 
 /// Decrements the number stored at key by decrement. If the key does not exist, it is set to 0
 /// before performing the operation. An error is returned if the key contains a value of the wrong
 /// type or contains a string that can not be represented as integer. This operation is limited to
 /// 64 bit signed integers.
-pub async fn decr_by(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    let by: i64 = (&Value::new(&args[2])).try_into()?;
-    conn.db().incr(&args[1], by.neg()).map(|n| n.into())
+pub async fn decr_by(conn: &Connection, args: VecDeque<Bytes>) -> Result<Value, Error> {
+    let by: i64 = (&Value::new(&args[1])).try_into()?;
+    conn.db().incr(&args[0], by.neg()).map(|n| n.into())
 }
 
 /// Get the value of key. If the key does not exist the special value nil is returned. An error is
 /// returned if the value stored at key is not a string, because GET only handles string values.
-pub async fn get(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    Ok(conn.db().get(&args[1]))
+pub async fn get(conn: &Connection, args: VecDeque<Bytes>) -> Result<Value, Error> {
+    Ok(conn.db().get(&args[0]))
 }
 
 /// Get the value of key and optionally set its expiration. GETEX is similar to
 /// GET, but is a write command with additional options.
-pub async fn getex(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
+pub async fn getex(conn: &Connection, args: VecDeque<Bytes>) -> Result<Value, Error> {
     let (expires_in, persist) = match args.len() {
         2 => (None, false),
         3 => {
@@ -124,131 +126,129 @@ pub async fn getex(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
 
 /// Get the value of key. If the key does not exist the special value nil is returned. An error is
 /// returned if the value stored at key is not a string, because GET only handles string values.
-pub async fn getrange(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    match conn.db().get(&args[1]) {
-        Value::Blob(binary) => {
-            let start = bytes_to_number::<i64>(&args[2])?;
-            let end = bytes_to_number::<i64>(&args[3])?;
-            let len = binary.len();
+pub async fn getrange(conn: &Connection, args: VecDeque<Bytes>) -> Result<Value, Error> {
+    let bytes = match conn.db().get(&args[0]) {
+        Value::Blob(binary) => binary,
+        Value::BlobRw(binary) => binary.freeze(),
+        Value::Null => return Ok("".into()),
+        _ => return Err(Error::WrongType),
+    };
 
-            // resolve negative positions
-            let start: usize = if start < 0 {
-                (start + len as i64).try_into().unwrap_or(0)
-            } else {
-                start.try_into().expect("Positive number")
-            };
+    let start = bytes_to_number::<i64>(&args[1])?;
+    let end = bytes_to_number::<i64>(&args[2])?;
+    let len = bytes.len();
 
-            // resolve negative positions
-            let end: usize = if end < 0 {
-                if let Ok(val) = (end + len as i64).try_into() {
-                    val
-                } else {
-                    return Ok("".into());
-                }
-            } else {
-                end.try_into().expect("Positive number")
-            };
-            let end = min(end, len.checked_sub(1).unwrap_or_default());
+    // resolve negative positions
+    let start: usize = if start < 0 {
+        (start + len as i64).try_into().unwrap_or(0)
+    } else {
+        start.try_into().expect("Positive number")
+    };
 
-            if end < start {
-                return Ok("".into());
-            }
-
-            Ok(Value::Blob(
-                binary
-                    .freeze()
-                    .slice((Bound::Included(start), Bound::Included(end)))
-                    .as_ref()
-                    .into(),
-            ))
+    // resolve negative positions
+    let end: usize = if end < 0 {
+        if let Ok(val) = (end + len as i64).try_into() {
+            val
+        } else {
+            return Ok("".into());
         }
-        Value::Null => Ok("".into()),
-        _ => Err(Error::WrongType),
+    } else {
+        end.try_into().expect("Positive number")
+    };
+    let end = min(end, len.checked_sub(1).unwrap_or_default());
+
+    if end < start {
+        return Ok("".into());
     }
+
+    Ok(Value::Blob(
+        bytes.slice((Bound::Included(start), Bound::Included(end))),
+    ))
 }
 
 /// Get the value of key and delete the key. This command is similar to GET, except for the fact
 /// that it also deletes the key on success (if and only if the key's value type is a string).
-pub async fn getdel(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    Ok(conn.db().getdel(&args[1]))
+pub async fn getdel(conn: &Connection, args: VecDeque<Bytes>) -> Result<Value, Error> {
+    Ok(conn.db().getdel(&args[0]))
 }
 
 /// Atomically sets key to value and returns the old value stored at key. Returns an error when key
 /// exists but does not hold a string value. Any previous time to live associated with the key is
 /// discarded on successful SET operation.
-pub async fn getset(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    Ok(conn.db().getset(&args[1], Value::new(&args[2])))
+pub async fn getset(conn: &Connection, args: VecDeque<Bytes>) -> Result<Value, Error> {
+    Ok(conn.db().getset(&args[0], Value::new(&args[1])))
 }
 
 /// Returns the values of all specified keys. For every key that does not hold a string value or
 /// does not exist, the special value nil is returned. Because of this, the operation never fails.
-pub async fn mget(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    Ok(conn.db().get_multi(&args[1..]))
+pub async fn mget(conn: &Connection, args: VecDeque<Bytes>) -> Result<Value, Error> {
+    Ok(conn.db().get_multi(args))
 }
 
 /// Set key to hold the string value. If key already holds a value, it is overwritten, regardless
 /// of its type. Any previous time to live associated with the key is discarded on successful SET
 /// operation.
-pub async fn set(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    let len = args.len();
-    let mut i = 3;
+pub async fn set(conn: &Connection, mut args: VecDeque<Bytes>) -> Result<Value, Error> {
     let mut expiration = None;
     let mut keep_ttl = false;
     let mut override_value = Override::Yes;
     let mut return_previous = false;
 
+    let command = b"SET";
+    let key = args.pop_front().ok_or(Error::Syntax)?;
+    let value = args.pop_front().ok_or(Error::Syntax)?;
+
     loop {
-        if i >= len {
+        let arg = if let Some(arg) = args.pop_front() {
+            String::from_utf8_lossy(&arg).to_uppercase()
+        } else {
             break;
-        }
-        match String::from_utf8_lossy(&args[i]).to_uppercase().as_str() {
+        };
+
+        match arg.as_str() {
             "EX" => {
                 if expiration.is_some() {
                     return Err(Error::Syntax);
                 }
                 expiration = Some(Expiration::new(
-                    try_get_arg!(args, i + 1),
+                    &args.pop_front().ok_or(Error::Syntax)?,
                     false,
                     false,
-                    &args[0],
+                    command,
                 )?);
-                i += 1;
             }
             "PX" => {
                 if expiration.is_some() {
                     return Err(Error::Syntax);
                 }
                 expiration = Some(Expiration::new(
-                    try_get_arg!(args, i + 1),
+                    &args.pop_front().ok_or(Error::Syntax)?,
                     true,
                     false,
-                    &args[0],
+                    command,
                 )?);
-                i += 1;
             }
             "EXAT" => {
                 if expiration.is_some() {
                     return Err(Error::Syntax);
                 }
                 expiration = Some(Expiration::new(
-                    try_get_arg!(args, i + 1),
+                    &args.pop_front().ok_or(Error::Syntax)?,
                     false,
                     true,
-                    &args[0],
+                    command,
                 )?);
-                i += 1;
             }
             "PXAT" => {
                 if expiration.is_some() {
                     return Err(Error::Syntax);
                 }
                 expiration = Some(Expiration::new(
-                    try_get_arg!(args, i + 1),
+                    &args.pop_front().ok_or(Error::Syntax)?,
                     true,
                     true,
-                    &args[0],
+                    command,
                 )?);
-                i += 1;
             }
             "KEEPTTL" => keep_ttl = true,
             "NX" => override_value = Override::No,
@@ -256,13 +256,11 @@ pub async fn set(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
             "GET" => return_previous = true,
             _ => return Err(Error::Syntax),
         }
-
-        i += 1;
     }
     Ok(
         match conn.db().set_advanced(
-            &args[1],
-            Value::new(&args[2]),
+            key,
+            Value::Blob(value),
             expiration.map(|t| t.try_into()).transpose()?,
             override_value,
             keep_ttl,
@@ -282,11 +280,9 @@ pub async fn set(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
 ///
 /// It is not possible for clients to see that some of the keys were
 /// updated while others are unchanged.
-pub async fn mset(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    conn.db().multi_set(&args[1..], true).map_err(|e| match e {
-        Error::Syntax => {
-            Error::WrongNumberArgument(String::from_utf8_lossy(&args[0]).to_uppercase())
-        }
+pub async fn mset(conn: &Connection, args: VecDeque<Bytes>) -> Result<Value, Error> {
+    conn.db().multi_set(args, true).map_err(|e| match e {
+        Error::Syntax => Error::WrongNumberArgument("MSET".to_owned()),
         e => e,
     })
 }
@@ -301,11 +297,9 @@ pub async fn mset(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
 /// MSETNX is atomic, so all given keys are set at once. It is not possible for
 /// clients to see that some of the keys were updated while others are
 /// unchanged.
-pub async fn msetnx(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    conn.db().multi_set(&args[1..], false).map_err(|e| match e {
-        Error::Syntax => {
-            Error::WrongNumberArgument(String::from_utf8_lossy(&args[0]).to_uppercase())
-        }
+pub async fn msetnx(conn: &Connection, args: VecDeque<Bytes>) -> Result<Value, Error> {
+    conn.db().multi_set(args, false).map_err(|e| match e {
+        Error::Syntax => Error::WrongNumberArgument("MSETNX".to_owned()),
         e => e,
     })
 }
@@ -315,34 +309,51 @@ pub async fn msetnx(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
 ///
 /// SET mykey value
 /// EXPIRE mykey seconds
-pub async fn setex(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    let is_milliseconds = check_arg!(args, 0, "PSETEX");
+#[inline]
+async fn setex_ex(
+    command: &[u8],
+    is_milliseconds: bool,
+    conn: &Connection,
+    mut args: VecDeque<Bytes>,
+) -> Result<Value, Error> {
+    let key = args.pop_front().ok_or(Error::Syntax)?;
+    let expiration = args.pop_front().ok_or(Error::Syntax)?;
+    let value = args.pop_front().ok_or(Error::Syntax)?;
 
-    let expires_in = Expiration::new(&args[2], is_milliseconds, false, &args[0])?;
+    let expires_in = Expiration::new(&expiration, is_milliseconds, false, command)?;
 
     Ok(conn
         .db()
-        .set(&args[1], Value::new(&args[3]), Some(expires_in.try_into()?)))
+        .set(key, Value::Blob(value), Some(expires_in.try_into()?)))
+}
+
+/// Set key to hold the string value and set key to timeout after a given number
+/// of seconds. This command is equivalent to:
+pub async fn setex(conn: &Connection, args: VecDeque<Bytes>) -> Result<Value, Error> {
+    setex_ex(b"SETEX", false, conn, args).await
+}
+
+/// PSETEX works exactly like SETEX with the sole difference that the expire
+/// time is specified in milliseconds instead of seconds.
+pub async fn psetex(conn: &Connection, args: VecDeque<Bytes>) -> Result<Value, Error> {
+    setex_ex(b"PSETEX", true, conn, args).await
 }
 
 /// Set key to hold string value if key does not exist. In that case, it is
 /// equal to SET. When key already holds a value, no operation is performed.
 /// SETNX is short for "SET if Not eXists".
-pub async fn setnx(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    Ok(conn.db().set_advanced(
-        &args[1],
-        Value::new(&args[2]),
-        None,
-        Override::No,
-        false,
-        false,
-    ))
+pub async fn setnx(conn: &Connection, mut args: VecDeque<Bytes>) -> Result<Value, Error> {
+    let key = args.pop_front().ok_or(Error::Syntax)?;
+    let value = args.pop_front().ok_or(Error::Syntax)?;
+    Ok(conn
+        .db()
+        .set_advanced(key, Value::Blob(value), None, Override::No, false, false))
 }
 
 /// Returns the length of the string value stored at key. An error is returned when key holds a
 /// non-string value.
-pub async fn strlen(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
-    match conn.db().get(&args[1]) {
+pub async fn strlen(conn: &Connection, args: VecDeque<Bytes>) -> Result<Value, Error> {
+    match conn.db().get(&args[0]) {
         Value::Blob(x) => Ok(x.len().into()),
         Value::String(x) => Ok(x.len().into()),
         Value::Null => Ok(0.into()),
@@ -356,9 +367,9 @@ pub async fn strlen(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
 /// make offset fit. Non-existing keys are considered as empty strings, so this
 /// command will make sure it holds a string large enough to be able to set
 /// value at offset.
-pub async fn setrange(conn: &Connection, args: &[Bytes]) -> Result<Value, Error> {
+pub async fn setrange(conn: &Connection, args: VecDeque<Bytes>) -> Result<Value, Error> {
     conn.db()
-        .set_range(&args[1], bytes_to_number(&args[2])?, &args[3])
+        .set_range(&args[0], bytes_to_number(&args[1])?, &args[2])
 }
 
 #[cfg(test)]
@@ -741,7 +752,9 @@ mod test {
             run_command(&c, &["setrange", "foo", "30", "xxx"]).await,
         );
         assert_eq!(
-            Ok("\0\0xxx\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0xxx\0\0\0\0\0\0\0xxx".into()),
+            Ok(Value::BlobRw(
+                ("\0\0xxx\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0xxx\0\0\0\0\0\0\0xxx".into())
+            )),
             run_command(&c, &["get", "foo"]).await,
         );
     }

--- a/src/db/entry.rs
+++ b/src/db/entry.rs
@@ -94,6 +94,7 @@ impl Entry {
             &self.value,
             Value::Boolean(_)
                 | Value::Blob(_)
+                | Value::BlobRw(_)
                 | Value::BigInteger(_)
                 | Value::Integer(_)
                 | Value::Float(_)

--- a/src/db/scan.rs
+++ b/src/db/scan.rs
@@ -29,7 +29,7 @@ pub trait Scan {
     fn scan(
         &self,
         cursor: Cursor,
-        pattern: Option<&Bytes>,
+        pattern: Option<Bytes>,
         count: Option<usize>,
         typ: Option<Typ>,
     ) -> std::result::Result<Result, Error>;

--- a/src/db/utils.rs
+++ b/src/db/utils.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
 use bytes::Bytes;
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 use tokio::time::{Duration, Instant};
 
 pub(crate) fn far_future() -> Instant {
@@ -45,6 +45,14 @@ pub struct ExpirationOpts {
     pub GT: bool,
     /// Set expiry only when the new expiry is less than current one
     pub LT: bool,
+}
+
+impl TryFrom<Vec<Bytes>> for ExpirationOpts {
+    type Error = Error;
+
+    fn try_from(args: Vec<Bytes>) -> Result<Self, Self::Error> {
+        args.as_slice().try_into()
+    }
 }
 
 impl TryFrom<&[Bytes]> for ExpirationOpts {

--- a/src/dispatcher/mod.rs
+++ b/src/dispatcher/mod.rs
@@ -278,7 +278,7 @@ dispatcher! {
             true,
         },
         LPUSHX {
-            cmd::list::lpush,
+            cmd::list::lpushx,
             [Flag::Write Flag::DenyOom Flag::Fast],
             -3,
             1,
@@ -350,7 +350,7 @@ dispatcher! {
             true,
         },
         RPUSHX {
-            cmd::list::rpush,
+            cmd::list::rpushx,
             [Flag::Write Flag::DenyOom Flag::Fast],
             -3,
             1,
@@ -442,7 +442,7 @@ dispatcher! {
             true,
         },
         HMSET {
-            cmd::hash::hset,
+            cmd::hash::hmset,
             [Flag::Write Flag::DenyOom Flag::Fast],
             -3,
             1,
@@ -588,7 +588,7 @@ dispatcher! {
             true,
         },
         PEXPIRE {
-            cmd::key::expire,
+            cmd::key::pexpire,
             [Flag::Write Flag::Fast],
             3,
             1,
@@ -597,7 +597,7 @@ dispatcher! {
             true,
         },
         PEXPIREAT {
-            cmd::key::expire_at,
+            cmd::key::pexpire_at,
             [Flag::Write Flag::Fast],
             3,
             1,
@@ -615,7 +615,7 @@ dispatcher! {
             true,
         },
         PTTL {
-            cmd::key::ttl,
+            cmd::key::pttl,
             [Flag::ReadOnly Flag::Random Flag::Fast],
             2,
             1,
@@ -642,7 +642,7 @@ dispatcher! {
             true,
         },
         RENAMENX {
-            cmd::key::rename,
+            cmd::key::renamenx,
             [Flag::Write Flag::Write],
             3,
             1,
@@ -842,7 +842,7 @@ dispatcher! {
             true,
         },
         PSETEX {
-            cmd::string::setex,
+            cmd::string::psetex,
             [Flag::Write Flag::DenyOom],
             4,
             1,
@@ -992,7 +992,7 @@ dispatcher! {
             true,
         },
         PSUBSCRIBE {
-            cmd::pubsub::subscribe,
+            cmd::pubsub::psubscribe,
             [Flag::PubSub Flag::Random Flag::Loading Flag::Stale],
             -2,
             0,

--- a/src/dispatcher/mod.rs
+++ b/src/dispatcher/mod.rs
@@ -606,7 +606,7 @@ dispatcher! {
             true,
         },
         PEXPIRETIME {
-            cmd::key::expire_time,
+            cmd::key::p_expire_time,
             [Flag::Write Flag::Fast],
             2,
             1,


### PR DESCRIPTION
* Pass args by value (and therefore pass the ownership) to avoid cloning bytes.
* Pass key/value by ownership to the database mod
* Use VecDeque instead of [] to deconstruct the args easily
* Use Bytes for Value::Blob. Introduce Value::BlobRw, which is identical but will use BytesMut internally. Value::Blob will transform to Value::BlobRw on demand and there is no going back (there is no BlobRw to Blob)